### PR TITLE
Task #125974 fix: Update paypal plugin to use POST method instead of GET method to submit transaction to paypal

### DIFF
--- a/code/plugins/paypal/paypal.php
+++ b/code/plugins/paypal/paypal.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright  Copyright (c) 2009-2013 TechJoomla. All rights reserved.
+ * @copyright  Copyright (c) 2009-2018 TechJoomla. All rights reserved.
  * @license    GNU General Public License version 2, or later
  */
 // No direct access

--- a/code/plugins/paypal/paypal.php
+++ b/code/plugins/paypal/paypal.php
@@ -199,7 +199,7 @@ class PlgPaymentPaypal extends JPlugin
 			$submitVaues['cmd'] = $vars->cmd;
 		}
 
-		$submitVaues['custom']        = $vars->order_id;
+		$submitVaues['order_id']        = $vars->order_id;
 		$submitVaues['item_name']     = $vars->item_name;
 		$submitVaues['return']        = $vars->return;
 		$submitVaues['cancel_return'] = $vars->cancel_return;
@@ -208,12 +208,22 @@ class PlgPaymentPaypal extends JPlugin
 		$submitVaues['no_note']       = '1';
 		$submitVaues['rm']            = '2';
 		$submitVaues['amount']        = $vars->amount;
-		$submitVaues['lc']            = $vars->country_code;
+		$submitVaues['country_code']            = $vars->country_code;
 		$plgPaymentPaypalHelper       = new plgPaymentPaypalHelper;
 		$postaction                   = $plgPaymentPaypalHelper->buildPaypalUrl();
-		/* for offsite plugin */
-		$postvalues                   = http_build_query($submitVaues);
-		header('Location: ' . $postaction . '?' . $postvalues);
+
+		// Add PayPal URL as action_url/submiturl so that the data can be posted to PayPal - used in layout file of the plugin
+		$submitVaues['action_url'] = $postaction;
+		$submitVaues['submiturl'] = $postaction;
+
+		$vars = new stdclass;
+		$vars = (object) $submitVaues;
+
+		ob_start();
+		include dirname(__FILE__) . '/paypal/tmpl/recurring.php';
+		$html = ob_get_clean();
+
+		echo $html;
 	}
 
 	// ***************************Recurring Payment ***************************
@@ -250,7 +260,7 @@ class PlgPaymentPaypal extends JPlugin
 			$submitVaues['cmd'] = $vars->cmd;
 		}
 
-		$submitVaues['custom']        = $vars->order_id;
+		$submitVaues['order_id']        = $vars->order_id;
 		$submitVaues['item_name']     = $vars->item_name;
 		$submitVaues['return']        = $vars->return;
 		$submitVaues['cancel_return'] = $vars->cancel_return;
@@ -258,7 +268,7 @@ class PlgPaymentPaypal extends JPlugin
 		$submitVaues['currency_code'] = $vars->currency_code;
 		$submitVaues['no_note']       = '1';
 		$submitVaues['rm']            = '2';
-		$submitVaues['a3']            = $vars->amount;
+		$submitVaues['amount']            = $vars->amount;
 
 		if ($vars->recurring_frequency == 'QUARTERLY')
 		{
@@ -268,20 +278,28 @@ class PlgPaymentPaypal extends JPlugin
 		else
 		{
 			$submitVaues['p3'] = 1;
-			$submitVaues['t3'] = $vars->recurring_frequency;
+			$submitVaues['recurring_frequency'] = $vars->recurring_frequency;
 		}
 
-		$submitVaues['srt']     = $vars->recurring_count;
+		$submitVaues['recurring_count']     = $vars->recurring_count;
 		$submitVaues['src']     = 1;
 		$submitVaues['sra']     = 1;
 
-		// $submitVaues['TRIALBILLINGPERIOD']='DAY'; //Parameters to test Recurring payment
-		// $submitVaues['TRIALBILLINGFREQUENCY']=3; //Parameters to test Recurring payment
 		$plgPaymentPaypalHelper = new plgPaymentPaypalHelper;
 		$postaction             = $plgPaymentPaypalHelper->buildPaypalUrl();
-		/* for offsite plugin */
-		$postvalues             = http_build_query($submitVaues);
-		header('Location: ' . $postaction . '?' . $postvalues);
+
+		// Add PayPal URL as action_url/submiturl so that the data can be posted to PayPal - used in layout file of the plugin
+		$submitVaues['action_url'] = $postaction;
+		$submitVaues['submiturl'] = $postaction;
+
+		$vars = new stdclass;
+		$vars = (object) $submitVaues;
+
+		ob_start();
+		include dirname(__FILE__) . '/paypal/tmpl/recurring.php';
+		$html = ob_get_clean();
+
+		echo $html;
 	}
 
 	/**

--- a/code/plugins/paypal/paypal/tmpl/recurring.php
+++ b/code/plugins/paypal/paypal/tmpl/recurring.php
@@ -1,6 +1,6 @@
 <?php
 /**
- *  @copyright  Copyright (c) 2009-2013 TechJoomla. All rights reserved.
+ *  @copyright  Copyright (c) 2009-2018 TechJoomla. All rights reserved.
  *  @license    GNU General Public License version 2, or later
  */
 defined('_JEXEC') or die('Restricted access');
@@ -19,14 +19,14 @@ defined('_JEXEC') or die('Restricted access');
 
 		<input type="hidden" name="a3" value="<?php echo $vars->amount; ?>" />
 
-		<?php 
+		<?php
 		if($vars->recurring_frequency=='QUARTERLY') //For QUARTERLY recurring payment
 		{	?>
 			<input type="hidden" name="p3" value="3">
 			<input type="hidden" name="t3" value="MONTH">
 			<?php
 		}
-		else 
+		else
 		{
 			?>
 			<input type="hidden" name="p3" value="1">

--- a/code/plugins/paypal/paypal/tmpl/recurring.php
+++ b/code/plugins/paypal/paypal/tmpl/recurring.php
@@ -1,14 +1,12 @@
-<?php 
+<?php
 /**
  *  @copyright  Copyright (c) 2009-2013 TechJoomla. All rights reserved.
  *  @license    GNU General Public License version 2, or later
  */
-defined('_JEXEC') or die('Restricted access'); 
-
+defined('_JEXEC') or die('Restricted access');
 ?>
-
 <div class="tjcpg-wrapper">
-	<form action="<?php echo $vars->submiturl; //$vars->action_url ?>" class="form-horizontal" method="post">
+	<form action="<?php echo $vars->action_url; //$vars->submiturl; ?>" class="form-horizontal" method="post">
 		<input type="hidden" name="business" value="<?php echo $vars->business; ?>" />
 		<input type="hidden" name="custom" value="<?php echo $vars->order_id; ?>" />
 		<input type="hidden" name="item_name" value="<?php echo $vars->item_name; ?>" />
@@ -20,19 +18,23 @@ defined('_JEXEC') or die('Restricted access');
 		<input type="hidden" name="rm" value="2" />
 
 		<input type="hidden" name="a3" value="<?php echo $vars->amount; ?>" />
-		
-		<?php if($vars->recurring_frequency=='QUARTERLY') //For QUARTERLY recurring payment
-		{ ?>
+
+		<?php 
+		if($vars->recurring_frequency=='QUARTERLY') //For QUARTERLY recurring payment
+		{	?>
 			<input type="hidden" name="p3" value="3">
-			<input type="hidden" name="t3" value="MONTH"> 
-		<?php 
-		}else {
-		 ?>
+			<input type="hidden" name="t3" value="MONTH">
+			<?php
+		}
+		else 
+		{
+			?>
 			<input type="hidden" name="p3" value="1">
-			<input type="hidden" name="t3" value="<?php echo $vars->recurring_frequency;?>"> 
-		<?php 
-		}?>
-		<input type="hidden" name="srt" value="<?php echo $vars->recurring_count; ?>"> 
+			<input type="hidden" name="t3" value="<?php echo $vars->recurring_frequency;?>">
+			<?php
+		}
+		?>
+		<input type="hidden" name="srt" value="<?php echo $vars->recurring_count; ?>">
 		<input type="hidden" name="src" value="1">
 		<input type="hidden" name="sra" value="1">
 		<input type="hidden" name="no_shipping" value="1">


### PR DESCRIPTION
- Paypal has stopped support for GET method to send data to PayPal (NVP/SOAP) https://www.paypal-notice.com/en/Discontinue-Use-of-GET-Method-for-Classic-APIs/
- Code updated to send data for processing payment using POST method instead of GET method.