### PR TITLE
Issue #40 fix: pass name, address, city etc while placing the order so that the order details are shown prefilled on the 2checkout

### DIFF
--- a/code/plugins/2checkout/2checkout.php
+++ b/code/plugins/2checkout/2checkout.php
@@ -3,7 +3,7 @@
  * @package    Joomla Payments
  * @author     TechJoomla <extensions@techjoomla.com>
  * @website    http://techjoomla.com
- * @copyright  Copyright (C) 2005 - 2018 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (c) 2009-2018 TechJoomla. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/code/plugins/2checkout/2checkout.php
+++ b/code/plugins/2checkout/2checkout.php
@@ -1,7 +1,10 @@
 <?php
 /**
- * @copyright  Copyright (c) 2009-2015 TechJoomla. All rights reserved
- * @license    GNU General Public License version 2, or later
+ * @package    Joomla Payments
+ * @author     TechJoomla <extensions@techjoomla.com>
+ * @website    http://techjoomla.com
+ * @copyright  Copyright (C) 2005 - 2018 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
 
 // No direct access

--- a/code/plugins/2checkout/2checkout.php
+++ b/code/plugins/2checkout/2checkout.php
@@ -1,10 +1,11 @@
 <?php
 /**
- * @package    Joomla Payments
- * @author     TechJoomla <extensions@techjoomla.com>
- * @website    http://techjoomla.com
- * @copyright  Copyright (c) 2009-2018 TechJoomla. All rights reserved.
- * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @package     Joomla_Payments
+ * @subpackage  plg_payments_2checkout
+ *
+ * @author      Techjoomla <extensions@techjoomla.com>
+ * @copyright   Copyright (C) 2009 - 2018 Techjoomla. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
 // No direct access

--- a/code/plugins/2checkout/2checkout/helper.php
+++ b/code/plugins/2checkout/2checkout/helper.php
@@ -1,7 +1,11 @@
 <?php
 /**
- * @copyright  Copyright (c) 2009-2013 TechJoomla. All rights reserved.
- * @license    GNU General Public License version 2, or later
+ * @package     Joomla_Payments
+ * @subpackage  plg_payments_2checkout
+ *
+ * @author      Techjoomla <extensions@techjoomla.com>
+ * @copyright   Copyright (C) 2009 - 2018 Techjoomla. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
 defined('_JEXEC') or die(';)');

--- a/code/plugins/2checkout/2checkout/tmpl/default.php
+++ b/code/plugins/2checkout/2checkout/tmpl/default.php
@@ -1,7 +1,10 @@
 <?php
 /**
- *  @copyright  Copyright (c) 2009-2015 TechJoomla. All rights reserved
- *  @license    GNU General Public License version 2, or later
+ * @package    Joomla Payments
+ * @author     TechJoomla <extensions@techjoomla.com>
+ * @website    http://techjoomla.com
+ * @copyright  Copyright (C) 2005 - 2018 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
 defined('_JEXEC') or die('Restricted access');
 ?>
@@ -12,14 +15,21 @@ defined('_JEXEC') or die('Restricted access');
 	<input type="hidden" name="sid" value="<?php echo $vars->sid?>" />
 	<input type="hidden" name="cart_order_id" value="<?php echo $vars->order_id ?>" />
 	<input type="hidden" name="total" value="<?php echo sprintf('%02.2f',$vars->amount) ?>" />
-
 	<input type="hidden" name="demo" value="<?php echo  $vars->demo; ?>" />
-  <input type="hidden" name="merchant_order_id" value="<?php echo $vars->order_id ?>" />
+	<input type="hidden" name="merchant_order_id" value="<?php echo $vars->order_id ?>" />
 	<input type="hidden" name="fixed" value="Y" />
 	<input type="hidden" name="lang" value="<?php echo $vars->lang; ?>" />
-	<input type='hidden' name='return_url' value="<?php echo $vars->return;?>" >
-	<input type='hidden' name='x_receipt_link_url' value="<?php echo $vars->notify_url;?>" >
+	<input type='hidden' name='x_receipt_link_url' value="<?php echo $vars->return;?>" />
 	<input type="hidden" name="pay_method" value="<?php echo strtoupper($vars->pay_method); ?>" />
+	<input type="hidden" name="card_holder_name" value="<?php echo $vars->user_firstname . " " . $vars->user_lastname?>" />
+	<input type="hidden" name="email" value="<?php echo $vars->user_email?>" />
+	<input type="hidden" name="street_address" value="<?php echo $vars->address?>" />
+	<input type="hidden" name="street_address2" value="<?php echo $vars->address2?>" />
+	<input type="hidden" name="zip" value="<?php echo $vars->zipcode?>" />
+	<input type="hidden" name="phone" value="<?php echo $vars->contactNumber?>" />
+	<input type="hidden" name="city" value="<?php echo $vars->cityName?>" />
+	<input type="hidden" name="state" value="<?php echo $vars->stateName?>" />
+	<input type="hidden" name="country" value="<?php echo $vars->countryName?>" />
 	<input type="hidden" name="id_type" value="1" />
 		<div class="form-actions">
 			<input name='submit' type='submit' class="btn btn-success btn-large" value="<?php echo JText::_('SUBMIT'); ?>" >

--- a/code/plugins/2checkout/2checkout/tmpl/default.php
+++ b/code/plugins/2checkout/2checkout/tmpl/default.php
@@ -1,11 +1,13 @@
 <?php
 /**
- * @package    Joomla Payments
- * @author     TechJoomla <extensions@techjoomla.com>
- * @website    http://techjoomla.com
- * @copyright  Copyright (c) 2009-2018 TechJoomla. All rights reserved.
- * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @package     Joomla_Payments
+ * @subpackage  plg_payments_2checkout
+ *
+ * @author      Techjoomla <extensions@techjoomla.com>
+ * @copyright   Copyright (C) 2009 - 2018 Techjoomla. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
+
 defined('_JEXEC') or die('Restricted access');
 ?>
 
@@ -14,7 +16,7 @@ defined('_JEXEC') or die('Restricted access');
 	<div>
 	<input type="hidden" name="sid" value="<?php echo $vars->sid?>" />
 	<input type="hidden" name="cart_order_id" value="<?php echo $vars->order_id ?>" />
-	<input type="hidden" name="total" value="<?php echo sprintf('%02.2f',$vars->amount) ?>" />
+	<input type="hidden" name="total" value="<?php echo sprintf('%02.2f', $vars->amount) ?>" />
 	<input type="hidden" name="demo" value="<?php echo  $vars->demo; ?>" />
 	<input type="hidden" name="merchant_order_id" value="<?php echo $vars->order_id ?>" />
 	<input type="hidden" name="fixed" value="Y" />

--- a/code/plugins/2checkout/2checkout/tmpl/default.php
+++ b/code/plugins/2checkout/2checkout/tmpl/default.php
@@ -3,7 +3,7 @@
  * @package    Joomla Payments
  * @author     TechJoomla <extensions@techjoomla.com>
  * @website    http://techjoomla.com
- * @copyright  Copyright (C) 2005 - 2018 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (c) 2009-2018 TechJoomla. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
 defined('_JEXEC') or die('Restricted access');

--- a/code/plugins/2checkout/2checkout/tmpl/form.php
+++ b/code/plugins/2checkout/2checkout/tmpl/form.php
@@ -17,7 +17,7 @@ defined('_JEXEC') or die('Restricted access');
 	<input type="hidden" name="merchant_order_id" value="<?php echo $vars->order_id ?>" />
 	<input type="hidden" name="fixed" value="Y" />
 	<input type="hidden" name="lang" value="<?php echo $vars->lang; ?>" />
-	<input type='hidden' name='x_receipt_link_url' value="<?php echo $vars->notify_url;?>" >
+	<input type='hidden' name='x_receipt_link_url' value="<?php echo $vars->return;?>" >
 	<input type="hidden" name="pay_method" value="<?php echo strtoupper($vars->pay_method); ?>" />
 	<input type="hidden" name="card_holder_name" value="<?php echo $vars->user_firstname . " " . $vars->user_lastname?>" />
 	<input type="hidden" name="email" value="<?php echo $vars->user_email?>" />

--- a/code/plugins/2checkout/2checkout/tmpl/form.php
+++ b/code/plugins/2checkout/2checkout/tmpl/form.php
@@ -1,25 +1,33 @@
 <?php
 /**
- * @copyright  Copyright (c) 2009-2015 TechJoomla. All rights reserved
- *  @license    GNU General Public License version 2, or later
+ * @package    Joomla Payments
+ * @author     TechJoomla <extensions@techjoomla.com>
+ * @website    http://techjoomla.com
+ * @copyright  Copyright (C) 2005 - 2018 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
 defined('_JEXEC') or die('Restricted access');
-
- ?>
+?>
 <div class="tjcpg-wrapper">
 <form action="<?php echo $vars->action_url ?>" class="form-horizontal" method="post" id="paymentForm">
-
 	<input type="hidden" name="sid" value="<?php echo $vars->sid?>" />
 	<input type="hidden" name="cart_order_id" value="<?php echo $vars->order_id ?>" />
 	<input type="hidden" name="total" value="<?php echo sprintf('%02.2f',$vars->amount) ?>" />
-
 	<input type="hidden" name="demo" value="<?php echo  $vars->demo; ?>" />
-  <input type="hidden" name="merchant_order_id" value="<?php echo $vars->order_id ?>" />
+	<input type="hidden" name="merchant_order_id" value="<?php echo $vars->order_id ?>" />
 	<input type="hidden" name="fixed" value="Y" />
 	<input type="hidden" name="lang" value="<?php echo $vars->lang; ?>" />
-	<input type='hidden' name='return_url' value="<?php echo $vars->return;?>" >
 	<input type='hidden' name='x_receipt_link_url' value="<?php echo $vars->notify_url;?>" >
 	<input type="hidden" name="pay_method" value="<?php echo strtoupper($vars->pay_method); ?>" />
+	<input type="hidden" name="card_holder_name" value="<?php echo $vars->user_firstname . " " . $vars->user_lastname?>" />
+	<input type="hidden" name="email" value="<?php echo $vars->user_email?>" />
+	<input type="hidden" name="street_address" value="<?php echo $vars->address?>" />
+	<input type="hidden" name="street_address2" value="<?php echo $vars->address2?>" />
+	<input type="hidden" name="zip" value="<?php echo $vars->zipcode?>" />
+	<input type="hidden" name="phone" value="<?php echo $vars->contactNumber?>" />
+	<input type="hidden" name="city" value="<?php echo $vars->cityName?>" />
+	<input type="hidden" name="state" value="<?php echo $vars->stateName?>" />
+	<input type="hidden" name="country" value="<?php echo $vars->countryName?>" />
 	<input type="hidden" name="id_type" value="1" />
 	<div class="form-actions">
 		<input name="submit" type="submit" class="btn btn-success btn-large" value="Pay Now" >

--- a/code/plugins/2checkout/2checkout/tmpl/form.php
+++ b/code/plugins/2checkout/2checkout/tmpl/form.php
@@ -1,10 +1,11 @@
 <?php
 /**
- * @package    Joomla Payments
- * @author     TechJoomla <extensions@techjoomla.com>
- * @website    http://techjoomla.com
- * @copyright  Copyright (c) 2009-2018 TechJoomla. All rights reserved.
- * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @package     Joomla_Payments
+ * @subpackage  plg_payments_2checkout
+ *
+ * @author      Techjoomla <extensions@techjoomla.com>
+ * @copyright   Copyright (C) 2009 - 2018 Techjoomla. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 defined('_JEXEC') or die('Restricted access');
 ?>
@@ -12,7 +13,7 @@ defined('_JEXEC') or die('Restricted access');
 <form action="<?php echo $vars->action_url ?>" class="form-horizontal" method="post" id="paymentForm">
 	<input type="hidden" name="sid" value="<?php echo $vars->sid?>" />
 	<input type="hidden" name="cart_order_id" value="<?php echo $vars->order_id ?>" />
-	<input type="hidden" name="total" value="<?php echo sprintf('%02.2f',$vars->amount) ?>" />
+	<input type="hidden" name="total" value="<?php echo sprintf('%02.2f', $vars->amount) ?>" />
 	<input type="hidden" name="demo" value="<?php echo  $vars->demo; ?>" />
 	<input type="hidden" name="merchant_order_id" value="<?php echo $vars->order_id ?>" />
 	<input type="hidden" name="fixed" value="Y" />

--- a/code/plugins/2checkout/2checkout/tmpl/form.php
+++ b/code/plugins/2checkout/2checkout/tmpl/form.php
@@ -3,7 +3,7 @@
  * @package    Joomla Payments
  * @author     TechJoomla <extensions@techjoomla.com>
  * @website    http://techjoomla.com
- * @copyright  Copyright (C) 2005 - 2018 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (c) 2009-2018 TechJoomla. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
 defined('_JEXEC') or die('Restricted access');


### PR DESCRIPTION
The user needs to fill his details like name, address, phone number etc while placing the order as well as while making payment on 2checkout. To resolve this we need to send order data (user's name, address, email, phone etc to 2checkout while placing the order)